### PR TITLE
Add Docker artifacts for development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ matrix:
 
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -U tox
+install:
+  - pip install --upgrade -U pip
+  - pip install -U tox
 
 # command to run tests, e.g. python setup.py test
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ LABEL maintainer "DataMade <info@datamade.us>"
 RUN mkdir /app
 WORKDIR /app
 
+# Reference: https://civic-scraper.readthedocs.io/en/latest/install.html
 RUN pip install civic-scraper
 
+# Reference: https://civic-scraper.readthedocs.io/en/latest/contributing.html#get-started
 COPY ./requirements-dev.txt /app/requirements-dev.txt
 RUN pip install --no-cache-dir -r requirements-dev.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.8-slim
+LABEL maintainer "DataMade <info@datamade.us>"
+
+RUN mkdir /app
+WORKDIR /app
+
+RUN pip install civic-scraper
+
+COPY ./requirements-dev.txt /app/requirements-dev.txt
+RUN pip install --no-cache-dir -r requirements-dev.txt
+
+COPY ./setup.py /app/setup.py
+RUN python setup.py develop
+
+COPY . /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2.4'
+
+services:
+  scraper:
+    image: civic-scraper
+    container_name: civic-scraper
+    build: .
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/app
+    environment:
+      CIVIC_SCRAPER_DIR: ./data
+    command: civic-scraper scrape --download --url http://nc-nashcounty.civicplus.com/AgendaCenter

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,5 @@ services:
     volumes:
       - .:/app
     environment:
-      CIVIC_SCRAPER_DIR: ./data
+      CIVIC_SCRAPER_DIR: ./_data
     command: civic-scraper scrape --download --url http://nc-nashcounty.civicplus.com/AgendaCenter


### PR DESCRIPTION
# Description

See title.

## Notes

I didn't update the README because I'm not sure whether we want to preserve these or not. The container defaults to running the example scrape from the docs. To run an arbitrary command against the container:

`docker-compose run --rm scraper civic-scraper scrape [ additional arguments ]`

See [Usage](https://civic-scraper.readthedocs.io/en/latest/usage.html) for more.

The build is passing for Python 3.7 and 3.8 but failing for Python 3.6 due to dependency problems unrelated to this change set. I'll open an issue in the root repository. I think we can ignore these failures for this PR.

### Testing instructions

- Run the scraper and confirm the scrape finishes, and that output is available in the `_data/` directory: `docker-compose run --rm scraper` (Docker Compose should automatically build the image for you, since it doesn't exist)