### PR TITLE
Added scraping for more sites

### DIFF
--- a/tests/primegov_test.py
+++ b/tests/primegov_test.py
@@ -1,14 +1,39 @@
 import pytest
 import logging
+
 from civic_scraper.platforms import PrimeGovSite
 
 logging.basicConfig(level="DEBUG")
 
 primegov_sites = [
-    {'site': 'https://lacity.primegov.com/api/meeting/',
+    {'site': 'https://lacity.primegov.com/',
      'config': {
         'place': 'los angeles',
         'state_or_province': 'ca',
+     },
+    },
+    {'site': 'https://santafe.primegov.com/',
+     'config': {
+        'place': 'santa fe',
+        'state_or_province': 'nm',
+     },
+    },
+    {'site': 'https://sanantonio.primegov.com/',
+     'config': {
+        'place': 'san antonio',
+        'state_or_province': 'tx',
+     },
+    },
+    {'site': 'https://ventura.primegov.com/',
+     'config': {
+        'place': 'ventura',
+        'state_or_province': 'ca',
+     },
+    },
+    {'site': 'https://lasvegas.primegov.com/',
+     'config': {
+        'place': 'las vegas',
+        'state_or_province': 'nv',
      },
     },
 ]
@@ -16,7 +41,7 @@ primegov_sites = [
 def primegov_integration():
 
     for obj in primegov_sites:
-        scraper = PrimeGovSite(obj['site'])
+        scraper = PrimeGovSite(obj['site'], **obj['config'])
         data = scraper.scrape()
         assert len(data) > 0
 


### PR DESCRIPTION
## Overview

This PR adds more PrimeGov city URLs (Ventura, Las Vegas, San Antonio, and Santa Fe) to the scraper tester. For each city, there are multiple PrimeGov API endpoints that can be queried:

1. (GET) https://[city].primegov.com/api/meeting/search?from=[m/d/y]&to=[m/d/y]
2. (GET) https://[city].primegov.com/v2/PublicPortal/ListUpcomingMeetings
3. (GET) https://[city].primegov.com/v2/PublicPortal/ListArchivedMeetings?year=[year]
4. (POST) https://[city].primegov.com/api/search?

For now, I've hardcoded `PrimeGovSite.scrape()` to scrape only the first endpoint with the default search period as the past 30 days. In the future, if necessary, we could add a way to choose which endpoint to query.

## Testing Instructions
Run `docker-compose run --rm scraper python tests/primegov_test.py`

Handles #18 