### PR TITLE
Granicus JSON scraper

### DIFF
--- a/civic_scraper/platforms/__init__.py
+++ b/civic_scraper/platforms/__init__.py
@@ -1,5 +1,5 @@
 from .civic_plus.site import Site as CivicPlusSite
 from .legistar.site import LegistarSite
-from .granicus.site import GranicusSite
+from .granicus.site import GranicusSite, GranicusJSONSite
 from .civic_clerk.site import CivicClerkSite
 from .primegov.site import PrimeGovSite

--- a/civic_scraper/platforms/granicus/site.py
+++ b/civic_scraper/platforms/granicus/site.py
@@ -131,7 +131,7 @@ class GranicusJSONSite(base.Site):
         for meeting in sorted(meetings,reverse=True,key=lambda m: m['dateObj']):
             if meeting['dateObj'] > self.end_date:
                 continue
-            elif meeting['dateObj'] <= self.start_date:
+            elif meeting['dateObj'] < self.start_date:
                 break
 
             # some instances have test meetings with no url or upload name

--- a/civic_scraper/platforms/granicus/site.py
+++ b/civic_scraper/platforms/granicus/site.py
@@ -73,12 +73,13 @@ class GranicusSite(base.Site):
 
 
 class GranicusJSONSite(base.Site):
-    def __init__(self, url, place=None, state_or_province=None, start_date=None, end_date=None, view_id=None, cache=Cache()):
+    def __init__(self, url, committee_name_parser=None, place=None, state_or_province=None, start_date=None, end_date=None, view_id=None, cache=Cache()):
         self.url = url
         self.subdomain = urlparse(url).netloc.split('.')[0]
         self.place = place
         self.state_or_province = state_or_province
         self.cache = cache
+        self.committee_name_parser = committee_name_parser
 
         self.start_date = datetime.strptime(start_date, '%m/%d/%Y')
         self.end_date = datetime.strptime(end_date, '%m/%d/%Y')
@@ -97,7 +98,7 @@ class GranicusJSONSite(base.Site):
 
         e = {'url': url,
              'asset_name': asset_name,
-             'committee_name': '',
+             'committee_name': self.committee_name_parser(asset_name),
              'place': self.place,
              'state_or_province': self.state_or_province,
              'asset_type': 'Agenda',
@@ -156,7 +157,5 @@ class GranicusJSONSite(base.Site):
                 seen.add(meeting['agendauploadname'])
 
             sleep(1)
-
-        print(list(map(lambda e: e.url,agendas)))
 
         return agendas

--- a/civic_scraper/platforms/granicus/site.py
+++ b/civic_scraper/platforms/granicus/site.py
@@ -73,7 +73,7 @@ class GranicusSite(base.Site):
 
 
 class GranicusJSONSite(base.Site):
-    def __init__(self, url, place=None, state_or_province=None, start_date=None, end_date=None, cache=Cache()):
+    def __init__(self, url, place=None, state_or_province=None, start_date=None, end_date=None, view_id=None, cache=Cache()):
         self.url = url
         self.subdomain = urlparse(url).netloc.split('.')[0]
         self.place = place
@@ -82,6 +82,7 @@ class GranicusJSONSite(base.Site):
 
         self.start_date = datetime.strptime(start_date, '%m/%d/%Y')
         self.end_date = datetime.strptime(end_date, '%m/%d/%Y')
+        self.view_id = view_id
 
     def _get_meeting_id(self, object_id):
 
@@ -113,7 +114,7 @@ class GranicusJSONSite(base.Site):
         return datetime.strptime(meeting['date'], '%Y-%m-%d')
 
     def _getAgendaUrl(self, clip_id):
-        return f'https://{self.subdomain}.granicus.com/AgendaViewer.php?view_id=1&clip_id={clip_id}'
+        return f'https://{self.subdomain}.granicus.com/AgendaViewer.php?view_id={self.view_id}&clip_id={clip_id}'
 
     def scrape(self):
         session = Session()
@@ -156,6 +157,6 @@ class GranicusJSONSite(base.Site):
 
             sleep(1)
 
-        print(list(map(lambda e: e.meeting_date,agendas)))
+        print(list(map(lambda e: e.url,agendas)))
 
         return agendas

--- a/civic_scraper/platforms/granicus/site.py
+++ b/civic_scraper/platforms/granicus/site.py
@@ -1,6 +1,8 @@
+import re
+from time import sleep
+
 import civic_scraper
 import feedparser
-
 from civic_scraper import base
 from civic_scraper.base.asset import Asset, AssetCollection
 from civic_scraper.base.cache import Cache
@@ -68,3 +70,90 @@ class GranicusSite(base.Site):
                     asset.download(target_dir=dir_str, session=session)
 
         return ac
+
+
+class GranicusJSONSite(base.Site):
+    def __init__(self, url, place=None, state_or_province=None, start_date=None, end_date=None, cache=Cache()):
+        self.url = url
+        self.subdomain = urlparse(url).netloc.split('.')[0]
+        self.place = place
+        self.state_or_province = state_or_province
+        self.cache = cache
+
+        self.start_date = datetime.strptime(start_date, '%m/%d/%Y')
+        self.end_date = datetime.strptime(end_date, '%m/%d/%Y')
+
+    def _get_meeting_id(self, object_id):
+
+        pattern = r'http[s]?:\/\/[www.]?(\S*).granicus.com\/[\S]*'
+        match = re.match(pattern, self.url)
+        return f'granicus-{match.group(1)}-{object_id}'
+
+    def create_asset(self, entry, url):
+        asset_name = entry['name']
+        meeting_datetime = datetime.strptime(entry['date'], '%Y-%m-%d')
+        meeting_id = self._get_meeting_id(entry['id'])
+
+        e = {'url': url,
+             'asset_name': asset_name,
+             'committee_name': '',
+             'place': self.place,
+             'state_or_province': self.state_or_province,
+             'asset_type': 'Agenda',
+             'meeting_date': meeting_datetime.date(),
+             'meeting_time': '',
+             'meeting_id': meeting_id,
+             'scraped_by': f'civic-scraper_{civic_scraper.__version__}',
+             'content_type': 'pdf',
+             'content_length': None,
+            }
+        return Asset(**e)
+
+    def getMeetingDateObj(self, meeting):
+        return datetime.strptime(meeting['date'], '%Y-%m-%d')
+
+    def getAgendaUrl(self, clip_id):
+        return f'https://{self.subdomain}.granicus.com/AgendaViewer.php?view_id=1&clip_id={clip_id}'
+
+    def scrape(self):
+        session = Session()
+        session.headers.update({"User-Agent": "Mozilla/5.0 (X11; CrOS x86_64 12871.102.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.141 Safari/537.36"})
+
+        # we can't assume the response will be in 100% chronological order
+        response = session.get(self.url)
+        meetings = map(lambda m: dict(**m,**{'dateObj': self.getMeetingDateObj(m)}), response.json())
+
+        seen = set() # e.g. spanish captioned meetings have same agenda
+        agendas = AssetCollection()
+        for meeting in sorted(meetings,reverse=True,key=lambda m: m['dateObj']):
+            if meeting['dateObj'] > self.end_date:
+                continue
+            elif meeting['dateObj'] <= self.start_date:
+                break
+
+            # some instances have test meetings with no url or upload name
+            if not meeting['agendaurl'] and not meeting['agendauploadname']:
+                continue
+
+            if meeting['agendaurl']:
+                if meeting['agendaurl'] not in seen:
+                    agendas.append(self.create_asset(meeting, meeting['agendaurl']))
+                    seen.add(meeting['agendaurl'])
+
+                continue
+
+            if meeting['agendauploadname'] and meeting['agendauploadname'] in seen:
+                continue
+
+            # if page redirects, there should be a pdf on the other side
+            agenda_url = self.getAgendaUrl(meeting['id'])
+            agenda_resp = session.get(agenda_url)
+            if agenda_url != agenda_resp.url:
+                agendas.append(self.create_asset(meeting, agenda_url))
+                seen.add(meeting['agendauploadname'])
+
+            sleep(1)
+
+        print(list(map(lambda e: e.meeting_date,agendas)))
+
+        return agendas

--- a/tests/committee_name_parsers.py
+++ b/tests/committee_name_parsers.py
@@ -8,7 +8,7 @@ def la_county_committee_parser(name):
     else:
         return name.strip(', ')
 
-def la_usd_comittee_parser(name):
+def la_usd_committee_parser(name):
     print(name)
     board_strings = ('Board', 'Regular', 'Special')
     bos_meeting = any(s in name for s in board_strings)

--- a/tests/committee_name_parsers.py
+++ b/tests/committee_name_parsers.py
@@ -1,0 +1,30 @@
+import re
+
+def la_county_committee_parser(name):
+    bos_strings = ('BOS', 'Board')
+    bos_meeting = any((s in name for s in bos_strings))
+    if bos_meeting:
+        return 'Board of Supervisors'
+    else:
+        return name.strip(', ')
+
+def la_usd_comittee_parser(name):
+    print(name)
+    board_strings = ('Board', 'Regular', 'Special')
+    bos_meeting = any(s in name for s in board_strings)
+    if bos_meeting:
+        return 'Board of Education'
+
+    pattern = r'\d{2}-\d{2}-\d{2,4},? [- ]?([,&\w\s]*)[ -]? \d{1,2}:?\d{0,2} (AM|PM|a.m.|p.m.)?'
+    match = re.match(pattern, name)
+
+    if match and match.group(1):
+        committee = match.group(1).strip(', ')
+        committee_str_list = committee.split(' ')
+        if committee_str_list[-1] == 'Meeting':
+            return ' '.join(committee_str_list[:-1])
+        else:
+            return committee
+
+    else:
+        return name.strip(', ')

--- a/tests/granicus_site.py
+++ b/tests/granicus_site.py
@@ -5,7 +5,7 @@ from civic_scraper.platforms import GranicusSite, GranicusJSONSite
 logging.basicConfig(level="DEBUG")
 
 granicus_rss_sites = [
-    {'site': 'https://lacounty.granicus.com/ViewPublisherRSS.php?view_id=1&mode=agendas',
+    {'site': 'https://brookhavencityga.iqm2.com/Services/RSS.aspx?Feed=Calendar',
      'config': {
         'place': 'brookhaven',
         'state_or_province': 'ga',
@@ -26,18 +26,18 @@ granicus_rss_sites = [
 ]
 
 granicus_json_sites = [
-    # {'site': 'https://lacounty.granicus.com/services/archives/',
-    #     'config': {
-    #     'place': 'los_angeles',
-    #     'state_or_province': 'ca',
-    #     'start_date': '04/07/2019',
-    #     'end_date': '06/12/2019'
-    #     }
-    # },
+    {'site': 'https://lacounty.granicus.com/services/archives/',
+        'config': {
+        'place': 'los_angeles',
+        'state_or_province': 'ca',
+        'start_date': '04/07/2019',
+        'end_date': '06/12/2019'
+        }
+    },
     {'site': 'https://lausd.granicus.com/services/archives/',
         'config': {
-        'place': 'brookhaven',
-        'state_or_province': 'ga',
+        'place': 'los_angeles',
+        'state_or_province': 'ca',
         'start_date': '04/07/2019',
         'end_date': '06/12/2019'
         }
@@ -45,10 +45,10 @@ granicus_json_sites = [
 ]
 
 def granicus_integration():
-    # for obj in granicus_rss_sites:
-    #     scraper = GranicusSite(obj['site'], **obj['config'])
-    #     data = scraper.scrape()
-    #     assert len(data) > 0
+    for obj in granicus_rss_sites:
+        scraper = GranicusSite(obj['site'], **obj['config'])
+        data = scraper.scrape()
+        assert len(data) > 0
 
     for obj in granicus_json_sites:
         scraper = GranicusJSONSite(obj['site'], **obj['config'])

--- a/tests/granicus_site.py
+++ b/tests/granicus_site.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 from civic_scraper.platforms import GranicusSite, GranicusJSONSite
-from committee_name_parsers import la_county_committee_parser, la_usd_comittee_parser
+from committee_name_parsers import la_county_committee_parser, la_usd_committee_parser
 
 logging.basicConfig(level="DEBUG")
 
@@ -44,7 +44,7 @@ granicus_json_sites = [
         'start_date': '01/01/2022',
         'end_date': '12/31/2022',
         'view_id': 1,
-        'committee_name_parser': la_usd_comittee_parser
+        'committee_name_parser': la_usd_committee_parser
         }
     },
 ]

--- a/tests/granicus_site.py
+++ b/tests/granicus_site.py
@@ -31,7 +31,8 @@ granicus_json_sites = [
         'place': 'los_angeles',
         'state_or_province': 'ca',
         'start_date': '04/07/2019',
-        'end_date': '06/12/2019'
+        'end_date': '06/12/2019',
+        'view_id': 2
         }
     },
     {'site': 'https://lausd.granicus.com/services/archives/',
@@ -39,16 +40,17 @@ granicus_json_sites = [
         'place': 'los_angeles',
         'state_or_province': 'ca',
         'start_date': '04/07/2019',
-        'end_date': '06/12/2019'
+        'end_date': '06/12/2019',
+        'view_id': 1
         }
     },
 ]
 
 def granicus_integration():
-    for obj in granicus_rss_sites:
-        scraper = GranicusSite(obj['site'], **obj['config'])
-        data = scraper.scrape()
-        assert len(data) > 0
+    # for obj in granicus_rss_sites:
+    #     scraper = GranicusSite(obj['site'], **obj['config'])
+    #     data = scraper.scrape()
+    #     assert len(data) > 0
 
     for obj in granicus_json_sites:
         scraper = GranicusJSONSite(obj['site'], **obj['config'])

--- a/tests/granicus_site.py
+++ b/tests/granicus_site.py
@@ -1,11 +1,11 @@
 import pytest
 import logging
-from civic_scraper.platforms import GranicusSite
+from civic_scraper.platforms import GranicusSite, GranicusJSONSite
 
 logging.basicConfig(level="DEBUG")
 
-granicus_sites = [
-    {'site': 'https://brookhavencityga.iqm2.com/Services/RSS.aspx?Feed=Calendar',
+granicus_rss_sites = [
+    {'site': 'https://lacounty.granicus.com/ViewPublisherRSS.php?view_id=1&mode=agendas',
      'config': {
         'place': 'brookhaven',
         'state_or_province': 'ga',
@@ -25,9 +25,33 @@ granicus_sites = [
     },
 ]
 
+granicus_json_sites = [
+    # {'site': 'https://lacounty.granicus.com/services/archives/',
+    #     'config': {
+    #     'place': 'los_angeles',
+    #     'state_or_province': 'ca',
+    #     'start_date': '04/07/2019',
+    #     'end_date': '06/12/2019'
+    #     }
+    # },
+    {'site': 'https://lausd.granicus.com/services/archives/',
+        'config': {
+        'place': 'brookhaven',
+        'state_or_province': 'ga',
+        'start_date': '04/07/2019',
+        'end_date': '06/12/2019'
+        }
+    },
+]
+
 def granicus_integration():
-    for obj in granicus_sites:
-        scraper = GranicusSite(obj['site'], **obj['config'])
+    # for obj in granicus_rss_sites:
+    #     scraper = GranicusSite(obj['site'], **obj['config'])
+    #     data = scraper.scrape()
+    #     assert len(data) > 0
+
+    for obj in granicus_json_sites:
+        scraper = GranicusJSONSite(obj['site'], **obj['config'])
         data = scraper.scrape()
         assert len(data) > 0
 

--- a/tests/granicus_site.py
+++ b/tests/granicus_site.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 from civic_scraper.platforms import GranicusSite, GranicusJSONSite
+from committee_name_parsers import la_county_committee_parser, la_usd_comittee_parser
 
 logging.basicConfig(level="DEBUG")
 
@@ -30,27 +31,29 @@ granicus_json_sites = [
         'config': {
         'place': 'los_angeles',
         'state_or_province': 'ca',
-        'start_date': '04/07/2019',
-        'end_date': '06/12/2019',
-        'view_id': 2
+        'start_date': '01/01/2022',
+        'end_date': '12/31/2022',
+        'view_id': 2,
+        'committee_name_parser': la_county_committee_parser
         }
     },
     {'site': 'https://lausd.granicus.com/services/archives/',
         'config': {
         'place': 'los_angeles',
         'state_or_province': 'ca',
-        'start_date': '04/07/2019',
-        'end_date': '06/12/2019',
-        'view_id': 1
+        'start_date': '01/01/2022',
+        'end_date': '12/31/2022',
+        'view_id': 1,
+        'committee_name_parser': la_usd_comittee_parser
         }
     },
 ]
 
 def granicus_integration():
-    # for obj in granicus_rss_sites:
-    #     scraper = GranicusSite(obj['site'], **obj['config'])
-    #     data = scraper.scrape()
-    #     assert len(data) > 0
+    for obj in granicus_rss_sites:
+        scraper = GranicusSite(obj['site'], **obj['config'])
+        data = scraper.scrape()
+        assert len(data) > 0
 
     for obj in granicus_json_sites:
         scraper = GranicusJSONSite(obj['site'], **obj['config'])


### PR DESCRIPTION
## Overview

Implements a scraper that handles Granicus sites as described in #21.

## Notes

### Date Filter

This Granicus endpoint returns a list of all meetings on file for the legislative body. I added in a date filter so `GranicusJSONSite.scrape()` only returns agendas in the specified time period.


### Committee name

I tried to create parsers for the committee names of LA USD and LA BOS meetings.  

#### LA USD

For the LA USD meetings, the names follow a general pattern but there are deviations (typos, extra commas or spaces, etc) that trip up the regex expression I've written. I'd say it correctly extracts the committee names upwards of 90% of the time. Here are the committee names of USD meetings 2019 and 2021, respectively:
<img width="960" alt="lausd committees 2019" src="https://user-images.githubusercontent.com/36973363/165759606-d7af8fb4-ec69-4467-8613-2fb01bdd40e8.png">
<img width="961" alt="lausd committees 2021" src="https://user-images.githubusercontent.com/36973363/165759625-865cf953-e0d0-41e6-97a2-1301770754f1.png">

#### LA BOS

The LA BOS endpoint is simpler in that it only returns Board meetings. It's rare but at times the names don't follow any pattern at all. Here are the names for 2019 and 2021, respectively:
<img width="817" alt="bos 2019" src="https://user-images.githubusercontent.com/36973363/165760487-a283fc1d-737e-4f05-ba8c-d8f58d4f1d12.png">
<img width="831" alt="bos 2021" src="https://user-images.githubusercontent.com/36973363/165760514-ad160440-60b2-4293-92f1-9326cf748dae.png">


### `view_id`

The link to each agenda requires a specific `view_id` URL parameter. From what I can tell, it's used by Granicus to categorize different kinds of documents associated with a meeting. For LA USD, the `view_id` is 1 and for LA BOS it's 2. These values are specific to each Granicus instance so I found the correct IDs by trial and error.

## Testing instructions

Run `docker-compose run --rm scraper python tests/granicus_site.py`