### PR TITLE
LAPD scraper

### DIFF
--- a/civic_scraper/platforms/__init__.py
+++ b/civic_scraper/platforms/__init__.py
@@ -1,5 +1,5 @@
 from .civic_plus.site import Site as CivicPlusSite
 from .legistar.site import LegistarSite
-from .granicus.site import GranicusSite
+from .granicus.site import GranicusSite, GranicusJSONSite
 from .civic_clerk.site import CivicClerkSite
 from .primegov.site import PrimeGovSite

--- a/civic_scraper/platforms/__init__.py
+++ b/civic_scraper/platforms/__init__.py
@@ -3,3 +3,4 @@ from .legistar.site import LegistarSite
 from .granicus.site import GranicusSite, GranicusJSONSite
 from .civic_clerk.site import CivicClerkSite
 from .primegov.site import PrimeGovSite
+from .custom.lapd_commission.site import LAPDCommissionArchiveSite, LAPDCommisionLandingSite

--- a/civic_scraper/platforms/custom/lapd_commission.py
+++ b/civic_scraper/platforms/custom/lapd_commission.py
@@ -1,0 +1,87 @@
+import re
+from datetime import datetime, timedelta
+from urllib.parse import urlparse
+from requests import Session
+from collections import deque
+
+import civic_scraper
+from civic_scraper import base
+from civic_scraper.base.asset import Asset, AssetCollection
+from civic_scraper.base.cache import Cache
+
+
+class LAPDCommissionSite(base.Site):
+
+    def __init__(self, url, place=None, state_or_province=None, cache=Cache()):
+
+        self.url = url
+        self.base_url = "https://" + urlparse(url).netloc
+        self.primegov_instance = urlparse(url).netloc.split(".")[0]
+        self.place = place
+        self.state_or_province = state_or_province
+        self.cache = cache
+
+        self.session = Session()
+        self.session.headers[
+            "User-Agent"
+        ] = "Mozilla/5.0 (X11; CrOS x86_64 12871.102.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.141 Safari/537.36"
+
+        # Raise an error if a request gets a failing status code
+        self.session.hooks = {
+            "response": lambda r, *args, **kwargs: r.raise_for_status()
+        }
+
+    def create_asset(self, entry, document):
+
+        url = self._get_agenda_url(entry['id'])
+        meeting_datetime = datetime.fromisoformat(entry['dateTime'])
+        meeting_id = self._get_meeting_id(document['id'])
+
+        e = {
+            "url": url,
+            "asset_name": entry['title'],
+            "committee_name": None,
+            "place": self.place,
+            "state_or_province": self.state_or_province,
+            "asset_type": "Meeting",
+            "meeting_date": meeting_datetime.date(),
+            "meeting_time": meeting_datetime.time(),
+            "meeting_id": meeting_id,
+            "scraped_by": f'civic-scraper_{civic_scraper.__version__}',
+            "content_type": "html",
+            "content_length": None,
+        }
+
+        return Asset(**e)
+
+    def _get_agenda_url(self, id):
+
+        return f'{self.base_url}/Portal/MeetingPreview?compiledMeetingDocumentFileId={id}'
+
+    def _get_meeting_id(self, object_id):
+
+        pattern = r'http[s]?:\/\/[www.]?(\S*).primegov.com\/[\S]*'
+        match = re.match(pattern, self.url)
+        return f'primegov_{match.group(1)}_{object_id}'
+
+    def scrape(self, start_date=None, end_date=None):
+
+        # API requires both start and end dates
+        if not start_date or not end_date:
+            start_date = (datetime.today() - timedelta(days=30)).strftime('%m/%d/%Y')
+            end_date = datetime.today().strftime('%m/%d/%Y')
+
+        response = self.session.get(f'{self.base_url}/api/meeting/search?from={start_date}&to={end_date}')
+
+        ac = AssetCollection()
+
+        for meeting in response.json():
+            for entry in meeting['templates']:
+                if 'Agenda' in entry['title']:
+                    for doc in entry['compiledMeetingDocumentFiles']:
+                        # HTML files have a compileOutputCode of 3
+                        if doc['compileOutputType'] == 3:
+                            ac.append(self.create_asset(meeting, doc))
+
+        return ac
+

--- a/civic_scraper/platforms/custom/lapd_commission/site.py
+++ b/civic_scraper/platforms/custom/lapd_commission/site.py
@@ -1,0 +1,139 @@
+import re
+import lxml.html
+from time import sleep
+from datetime import datetime
+from urllib.parse import urlparse
+from requests import Session
+
+import civic_scraper
+from civic_scraper import base
+from civic_scraper.base.asset import Asset, AssetCollection
+from civic_scraper.base.cache import Cache
+
+
+class LAPDCommissionSite(base.Site):
+
+    def __init__(self, url, cache=Cache()):
+
+        self.url = url
+        self.cache = cache
+
+        self.session = Session()
+        self.session.headers[
+            "User-Agent"
+        ] = "Mozilla/5.0 (X11; CrOS x86_64 12871.102.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.141 Safari/537.36"
+
+        # Raise an error if a request gets a failing status code
+        self.session.hooks = {
+            "response": lambda r, *args, **kwargs: r.raise_for_status()
+        }
+
+    def _get_meeting_date(self, title):
+
+        pattern = r'([a-z,A-z]*)\s?(\d{1,2}),?\s?(\d{4})'
+        match = re.match(pattern, title)
+        month, day, year = match.group(1), match.group(2), match.group(3)
+
+        return datetime.strptime(f'{month} {day}, {year}','%B %d, %Y').date()
+
+    def create_asset(self, title, agenda_url):
+
+        meeting_date = self._get_meeting_date(title)
+        meeting_id = meeting_date.strftime('lapd_commission_%m_%d_Y')
+
+        e = {
+            "url": agenda_url,
+            "asset_name": title,
+            "committee_name": 'LAPD Commission',
+            "place": 'los_angeles',
+            "state_or_province": 'ca',
+            "asset_type": "Meeting",
+            "meeting_date": meeting_date,
+            "meeting_time": '',
+            "meeting_id": meeting_id,
+            "scraped_by": f'civic-scraper_{civic_scraper.__version__}',
+            "content_type": 'pdf',
+            "content_length": None,
+        }
+
+        return Asset(**e)
+
+    def _get_meeting_id(self, object_id):
+
+        pattern = r'http[s]?:\/\/[www.]?(\S*).primegov.com\/[\S]*'
+        match = re.match(pattern, self.url)
+        return f'primegov_{match.group(1)}_{object_id}'
+
+
+class LAPDCommisionLandingSite(LAPDCommissionSite):
+
+    def scrape(self):
+
+        ac = AssetCollection()
+        response = self.session.get(self.url)
+        landing_page_tree = lxml.html.fromstring(response.text)
+
+        agenda_element = landing_page_tree.xpath(
+            '//main//section[contains(@class,"related-links")][1]//a[1]'
+        )
+        agenda = agenda_element[0]
+        ac.append(self.create_asset(agenda.text, agenda.attrib['href']))
+
+        return ac
+
+
+class LAPDCommissionArchiveSite(LAPDCommissionSite):
+
+    def __init__(self, url, start_date=None, end_date=None, cache=Cache()):
+
+        self.start_date = datetime.strptime(start_date, '%m/%d/%Y')
+        self.end_date = datetime.strptime(end_date, '%m/%d/%Y')
+        super().__init__(url, cache)
+
+    def archive_year_agendas(self, archive_year_url):
+
+        year_page = self.session.get(archive_year_url)
+        year_page_tree = lxml.html.fromstring(year_page.text)
+        agenda_elements = year_page_tree.xpath(
+            '//main//section[contains(@class,"related-links")]//div[@class="container"]//a'
+        )
+        
+        for agenda in agenda_elements:
+            if 'Public Comments' in agenda.text:
+                continue
+
+            meeting_date = self._get_meeting_date(agenda.text)
+            if meeting_date > self.end_date.date():
+                continue
+            elif meeting_date < self.start_date.date():
+                return
+
+            yield agenda
+
+    def scrape(self):
+
+        ac = AssetCollection()
+
+        response = self.session.get(self.url)
+        archives_page_tree = lxml.html.fromstring(response.text)
+
+        archive_years_elements = archives_page_tree.xpath(
+            '//section[@class="cmn-table"]//div[@class="container"]//a'
+        )
+        archive_years_urls = map(
+            lambda e: (e.text, e.attrib['href']), archive_years_elements
+        )
+
+        for year, url in archive_years_urls:
+            # agendas are grouped by year
+            if int(year) > self.end_date.year:
+                continue
+            elif int(year) < self.start_date.year:
+                break
+
+            for agenda in self.archive_year_agendas(url):
+                ac.append(self.create_asset(agenda.text, agenda.attrib['href']))
+
+            sleep(1)
+
+        return ac

--- a/civic_scraper/platforms/granicus/site.py
+++ b/civic_scraper/platforms/granicus/site.py
@@ -131,7 +131,7 @@ class GranicusJSONSite(base.Site):
         for meeting in sorted(meetings,reverse=True,key=lambda m: m['dateObj']):
             if meeting['dateObj'] > self.end_date:
                 continue
-            elif meeting['dateObj'] <= self.start_date:
+            elif meeting['dateObj'] < self.start_date:
                 break
 
             # some instances have test meetings with no url or upload name

--- a/civic_scraper/platforms/granicus/site.py
+++ b/civic_scraper/platforms/granicus/site.py
@@ -73,12 +73,13 @@ class GranicusSite(base.Site):
 
 
 class GranicusJSONSite(base.Site):
-    def __init__(self, url, place=None, state_or_province=None, start_date=None, end_date=None, view_id=None, cache=Cache()):
+    def __init__(self, url, committee_name_parser=None, place=None, state_or_province=None, start_date=None, end_date=None, view_id=None, cache=Cache()):
         self.url = url
         self.subdomain = urlparse(url).netloc.split('.')[0]
         self.place = place
         self.state_or_province = state_or_province
         self.cache = cache
+        self.committee_name_parser = committee_name_parser
 
         self.start_date = datetime.strptime(start_date, '%m/%d/%Y')
         self.end_date = datetime.strptime(end_date, '%m/%d/%Y')
@@ -97,7 +98,7 @@ class GranicusJSONSite(base.Site):
 
         e = {'url': url,
              'asset_name': asset_name,
-             'committee_name': '',
+             'committee_name': self.committee_name_parser(asset_name),
              'place': self.place,
              'state_or_province': self.state_or_province,
              'asset_type': 'Agenda',
@@ -156,7 +157,5 @@ class GranicusJSONSite(base.Site):
                 seen.add(meeting['agendauploadname'])
 
             sleep(1)
-
-        print(list(map(lambda e: e.url,agendas)))
 
         return agendas

--- a/civic_scraper/platforms/granicus/site.py
+++ b/civic_scraper/platforms/granicus/site.py
@@ -73,7 +73,7 @@ class GranicusSite(base.Site):
 
 
 class GranicusJSONSite(base.Site):
-    def __init__(self, url, place=None, state_or_province=None, start_date=None, end_date=None, cache=Cache()):
+    def __init__(self, url, place=None, state_or_province=None, start_date=None, end_date=None, view_id=None, cache=Cache()):
         self.url = url
         self.subdomain = urlparse(url).netloc.split('.')[0]
         self.place = place
@@ -82,6 +82,7 @@ class GranicusJSONSite(base.Site):
 
         self.start_date = datetime.strptime(start_date, '%m/%d/%Y')
         self.end_date = datetime.strptime(end_date, '%m/%d/%Y')
+        self.view_id = view_id
 
     def _get_meeting_id(self, object_id):
 
@@ -113,7 +114,7 @@ class GranicusJSONSite(base.Site):
         return datetime.strptime(meeting['date'], '%Y-%m-%d')
 
     def _getAgendaUrl(self, clip_id):
-        return f'https://{self.subdomain}.granicus.com/AgendaViewer.php?view_id=1&clip_id={clip_id}'
+        return f'https://{self.subdomain}.granicus.com/AgendaViewer.php?view_id={self.view_id}&clip_id={clip_id}'
 
     def scrape(self):
         session = Session()
@@ -156,6 +157,6 @@ class GranicusJSONSite(base.Site):
 
             sleep(1)
 
-        print(list(map(lambda e: e.meeting_date,agendas)))
+        print(list(map(lambda e: e.url,agendas)))
 
         return agendas

--- a/civic_scraper/platforms/granicus/site.py
+++ b/civic_scraper/platforms/granicus/site.py
@@ -1,6 +1,8 @@
+import re
+from time import sleep
+
 import civic_scraper
 import feedparser
-
 from civic_scraper import base
 from civic_scraper.base.asset import Asset, AssetCollection
 from civic_scraper.base.cache import Cache
@@ -68,3 +70,90 @@ class GranicusSite(base.Site):
                     asset.download(target_dir=dir_str, session=session)
 
         return ac
+
+
+class GranicusJSONSite(base.Site):
+    def __init__(self, url, place=None, state_or_province=None, start_date=None, end_date=None, cache=Cache()):
+        self.url = url
+        self.subdomain = urlparse(url).netloc.split('.')[0]
+        self.place = place
+        self.state_or_province = state_or_province
+        self.cache = cache
+
+        self.start_date = datetime.strptime(start_date, '%m/%d/%Y')
+        self.end_date = datetime.strptime(end_date, '%m/%d/%Y')
+
+    def _get_meeting_id(self, object_id):
+
+        pattern = r'http[s]?:\/\/[www.]?(\S*).granicus.com\/[\S]*'
+        match = re.match(pattern, self.url)
+        return f'granicus-{match.group(1)}-{object_id}'
+
+    def create_asset(self, entry, url):
+        asset_name = entry['name']
+        meeting_datetime = datetime.strptime(entry['date'], '%Y-%m-%d')
+        meeting_id = self._get_meeting_id(entry['id'])
+
+        e = {'url': url,
+             'asset_name': asset_name,
+             'committee_name': '',
+             'place': self.place,
+             'state_or_province': self.state_or_province,
+             'asset_type': 'Agenda',
+             'meeting_date': meeting_datetime.date(),
+             'meeting_time': '',
+             'meeting_id': meeting_id,
+             'scraped_by': f'civic-scraper_{civic_scraper.__version__}',
+             'content_type': 'pdf',
+             'content_length': None,
+            }
+        return Asset(**e)
+
+    def getMeetingDateObj(self, meeting):
+        return datetime.strptime(meeting['date'], '%Y-%m-%d')
+
+    def getAgendaUrl(self, clip_id):
+        return f'https://{self.subdomain}.granicus.com/AgendaViewer.php?view_id=1&clip_id={clip_id}'
+
+    def scrape(self):
+        session = Session()
+        session.headers.update({"User-Agent": "Mozilla/5.0 (X11; CrOS x86_64 12871.102.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.141 Safari/537.36"})
+
+        # we can't assume the response will be in 100% chronological order
+        response = session.get(self.url)
+        meetings = map(lambda m: dict(**m,**{'dateObj': self.getMeetingDateObj(m)}), response.json())
+
+        seen = set() # e.g. spanish captioned meetings have same agenda
+        agendas = AssetCollection()
+        for meeting in sorted(meetings,reverse=True,key=lambda m: m['dateObj']):
+            if meeting['dateObj'] > self.end_date:
+                continue
+            elif meeting['dateObj'] <= self.start_date:
+                break
+
+            # some instances have test meetings with no url or upload name
+            if not meeting['agendaurl'] and not meeting['agendauploadname']:
+                continue
+
+            if meeting['agendaurl']:
+                if meeting['agendaurl'] not in seen:
+                    agendas.append(self.create_asset(meeting, meeting['agendaurl']))
+                    seen.add(meeting['agendaurl'])
+
+                continue
+
+            if meeting['agendauploadname'] and meeting['agendauploadname'] in seen:
+                continue
+
+            # if page redirects, there should be a pdf on the other side
+            agenda_url = self.getAgendaUrl(meeting['id'])
+            agenda_resp = session.get(agenda_url)
+            if agenda_url != agenda_resp.url:
+                agendas.append(self.create_asset(meeting, agenda_url))
+                seen.add(meeting['agendauploadname'])
+
+            sleep(1)
+
+        print(list(map(lambda e: e.meeting_date,agendas)))
+
+        return agendas

--- a/tests/committee_name_parsers.py
+++ b/tests/committee_name_parsers.py
@@ -8,7 +8,7 @@ def la_county_committee_parser(name):
     else:
         return name.strip(', ')
 
-def la_usd_comittee_parser(name):
+def la_usd_committee_parser(name):
     print(name)
     board_strings = ('Board', 'Regular', 'Special')
     bos_meeting = any(s in name for s in board_strings)

--- a/tests/committee_name_parsers.py
+++ b/tests/committee_name_parsers.py
@@ -1,0 +1,30 @@
+import re
+
+def la_county_committee_parser(name):
+    bos_strings = ('BOS', 'Board')
+    bos_meeting = any((s in name for s in bos_strings))
+    if bos_meeting:
+        return 'Board of Supervisors'
+    else:
+        return name.strip(', ')
+
+def la_usd_comittee_parser(name):
+    print(name)
+    board_strings = ('Board', 'Regular', 'Special')
+    bos_meeting = any(s in name for s in board_strings)
+    if bos_meeting:
+        return 'Board of Education'
+
+    pattern = r'\d{2}-\d{2}-\d{2,4},? [- ]?([,&\w\s]*)[ -]? \d{1,2}:?\d{0,2} (AM|PM|a.m.|p.m.)?'
+    match = re.match(pattern, name)
+
+    if match and match.group(1):
+        committee = match.group(1).strip(', ')
+        committee_str_list = committee.split(' ')
+        if committee_str_list[-1] == 'Meeting':
+            return ' '.join(committee_str_list[:-1])
+        else:
+            return committee
+
+    else:
+        return name.strip(', ')

--- a/tests/granicus_site.py
+++ b/tests/granicus_site.py
@@ -5,7 +5,7 @@ from civic_scraper.platforms import GranicusSite, GranicusJSONSite
 logging.basicConfig(level="DEBUG")
 
 granicus_rss_sites = [
-    {'site': 'https://lacounty.granicus.com/ViewPublisherRSS.php?view_id=1&mode=agendas',
+    {'site': 'https://brookhavencityga.iqm2.com/Services/RSS.aspx?Feed=Calendar',
      'config': {
         'place': 'brookhaven',
         'state_or_province': 'ga',
@@ -26,18 +26,18 @@ granicus_rss_sites = [
 ]
 
 granicus_json_sites = [
-    # {'site': 'https://lacounty.granicus.com/services/archives/',
-    #     'config': {
-    #     'place': 'los_angeles',
-    #     'state_or_province': 'ca',
-    #     'start_date': '04/07/2019',
-    #     'end_date': '06/12/2019'
-    #     }
-    # },
+    {'site': 'https://lacounty.granicus.com/services/archives/',
+        'config': {
+        'place': 'los_angeles',
+        'state_or_province': 'ca',
+        'start_date': '04/07/2019',
+        'end_date': '06/12/2019'
+        }
+    },
     {'site': 'https://lausd.granicus.com/services/archives/',
         'config': {
-        'place': 'brookhaven',
-        'state_or_province': 'ga',
+        'place': 'los_angeles',
+        'state_or_province': 'ca',
         'start_date': '04/07/2019',
         'end_date': '06/12/2019'
         }
@@ -45,10 +45,10 @@ granicus_json_sites = [
 ]
 
 def granicus_integration():
-    # for obj in granicus_rss_sites:
-    #     scraper = GranicusSite(obj['site'], **obj['config'])
-    #     data = scraper.scrape()
-    #     assert len(data) > 0
+    for obj in granicus_rss_sites:
+        scraper = GranicusSite(obj['site'], **obj['config'])
+        data = scraper.scrape()
+        assert len(data) > 0
 
     for obj in granicus_json_sites:
         scraper = GranicusJSONSite(obj['site'], **obj['config'])

--- a/tests/granicus_site.py
+++ b/tests/granicus_site.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 from civic_scraper.platforms import GranicusSite, GranicusJSONSite
-from committee_name_parsers import la_county_committee_parser, la_usd_comittee_parser
+from committee_name_parsers import la_county_committee_parser, la_usd_committee_parser
 
 logging.basicConfig(level="DEBUG")
 
@@ -44,7 +44,7 @@ granicus_json_sites = [
         'start_date': '01/01/2022',
         'end_date': '12/31/2022',
         'view_id': 1,
-        'committee_name_parser': la_usd_comittee_parser
+        'committee_name_parser': la_usd_committee_parser
         }
     },
 ]

--- a/tests/granicus_site.py
+++ b/tests/granicus_site.py
@@ -31,7 +31,8 @@ granicus_json_sites = [
         'place': 'los_angeles',
         'state_or_province': 'ca',
         'start_date': '04/07/2019',
-        'end_date': '06/12/2019'
+        'end_date': '06/12/2019',
+        'view_id': 2
         }
     },
     {'site': 'https://lausd.granicus.com/services/archives/',
@@ -39,16 +40,17 @@ granicus_json_sites = [
         'place': 'los_angeles',
         'state_or_province': 'ca',
         'start_date': '04/07/2019',
-        'end_date': '06/12/2019'
+        'end_date': '06/12/2019',
+        'view_id': 1
         }
     },
 ]
 
 def granicus_integration():
-    for obj in granicus_rss_sites:
-        scraper = GranicusSite(obj['site'], **obj['config'])
-        data = scraper.scrape()
-        assert len(data) > 0
+    # for obj in granicus_rss_sites:
+    #     scraper = GranicusSite(obj['site'], **obj['config'])
+    #     data = scraper.scrape()
+    #     assert len(data) > 0
 
     for obj in granicus_json_sites:
         scraper = GranicusJSONSite(obj['site'], **obj['config'])

--- a/tests/granicus_site.py
+++ b/tests/granicus_site.py
@@ -1,11 +1,11 @@
 import pytest
 import logging
-from civic_scraper.platforms import GranicusSite
+from civic_scraper.platforms import GranicusSite, GranicusJSONSite
 
 logging.basicConfig(level="DEBUG")
 
-granicus_sites = [
-    {'site': 'https://brookhavencityga.iqm2.com/Services/RSS.aspx?Feed=Calendar',
+granicus_rss_sites = [
+    {'site': 'https://lacounty.granicus.com/ViewPublisherRSS.php?view_id=1&mode=agendas',
      'config': {
         'place': 'brookhaven',
         'state_or_province': 'ga',
@@ -25,9 +25,33 @@ granicus_sites = [
     },
 ]
 
+granicus_json_sites = [
+    # {'site': 'https://lacounty.granicus.com/services/archives/',
+    #     'config': {
+    #     'place': 'los_angeles',
+    #     'state_or_province': 'ca',
+    #     'start_date': '04/07/2019',
+    #     'end_date': '06/12/2019'
+    #     }
+    # },
+    {'site': 'https://lausd.granicus.com/services/archives/',
+        'config': {
+        'place': 'brookhaven',
+        'state_or_province': 'ga',
+        'start_date': '04/07/2019',
+        'end_date': '06/12/2019'
+        }
+    },
+]
+
 def granicus_integration():
-    for obj in granicus_sites:
-        scraper = GranicusSite(obj['site'], **obj['config'])
+    # for obj in granicus_rss_sites:
+    #     scraper = GranicusSite(obj['site'], **obj['config'])
+    #     data = scraper.scrape()
+    #     assert len(data) > 0
+
+    for obj in granicus_json_sites:
+        scraper = GranicusJSONSite(obj['site'], **obj['config'])
         data = scraper.scrape()
         assert len(data) > 0
 

--- a/tests/granicus_site.py
+++ b/tests/granicus_site.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 from civic_scraper.platforms import GranicusSite, GranicusJSONSite
+from committee_name_parsers import la_county_committee_parser, la_usd_comittee_parser
 
 logging.basicConfig(level="DEBUG")
 
@@ -30,27 +31,29 @@ granicus_json_sites = [
         'config': {
         'place': 'los_angeles',
         'state_or_province': 'ca',
-        'start_date': '04/07/2019',
-        'end_date': '06/12/2019',
-        'view_id': 2
+        'start_date': '01/01/2022',
+        'end_date': '12/31/2022',
+        'view_id': 2,
+        'committee_name_parser': la_county_committee_parser
         }
     },
     {'site': 'https://lausd.granicus.com/services/archives/',
         'config': {
         'place': 'los_angeles',
         'state_or_province': 'ca',
-        'start_date': '04/07/2019',
-        'end_date': '06/12/2019',
-        'view_id': 1
+        'start_date': '01/01/2022',
+        'end_date': '12/31/2022',
+        'view_id': 1,
+        'committee_name_parser': la_usd_comittee_parser
         }
     },
 ]
 
 def granicus_integration():
-    # for obj in granicus_rss_sites:
-    #     scraper = GranicusSite(obj['site'], **obj['config'])
-    #     data = scraper.scrape()
-    #     assert len(data) > 0
+    for obj in granicus_rss_sites:
+        scraper = GranicusSite(obj['site'], **obj['config'])
+        data = scraper.scrape()
+        assert len(data) > 0
 
     for obj in granicus_json_sites:
         scraper = GranicusJSONSite(obj['site'], **obj['config'])

--- a/tests/lapd_commission_site.py
+++ b/tests/lapd_commission_site.py
@@ -1,0 +1,28 @@
+import pytest
+import logging
+from civic_scraper.platforms import LAPDCommissionArchiveSite
+from civic_scraper.platforms.custom.lapd_commission.site import LAPDCommisionLandingSite, LAPDCommisionLandingSite
+
+logging.basicConfig(level="DEBUG")
+
+archive = {
+    'site': 'https://www.lapdonline.org/police-commission/police-commission-meetings-archives/',
+    'config': {
+        'start_date': '08/12/2020',
+        'end_date': '02/04/2021'
+    }
+}
+
+landing_site = 'https://www.lapdonline.org/police-commission/'
+
+def lapd_commission_integration():
+    archive_scraper = LAPDCommissionArchiveSite(archive['site'], **archive['config'])
+    data = archive_scraper.scrape()
+    assert len(data) > 0
+
+    landing_site_scraper = LAPDCommisionLandingSite(landing_site)
+    data = landing_site_scraper.scrape()
+    assert len(data) > 0
+
+if __name__ == '__main__':
+    lapd_commission_integration()


### PR DESCRIPTION
## Overview

This PR implements agenda scrapers for the LAPD Commission.

## Notes

1. I took some cues from [Serdar's comment](https://github.com/datamade/civic-scraper/issues/23#issuecomment-1112560859) on issue #23 and implemented two scrapers: one for the [landing page](https://www.lapdonline.org/police-commission/) (`LAPDCommisionLandingSite`) and one for the [archives](https://www.lapdonline.org/police-commission/police-commission-meetings-archives/) (`LAPDCommissionArchiveSite`). I decided on two scrapers to follow the pattern of each scraper class having one `scrape()` function. Both are subclasses of `LAPDCommisionSite`.
2. The archive scraper accepts date options while the landing page scraper does not. As far as I know, the landing page only displays one agenda at a time.
3. Since this would be (to my knowledge) the first scraper in the repo without a platform (CivicPlus, Granicus, Primegov, etc.), I placed the new scrapers in `civic-scraper/platforms/custom/lapd_commission/site.py`.

## Testing Instructions

- Run `docker-compose run --rm scraper python tests/lapd_commission_site.py`